### PR TITLE
Fixed unitialized streamID within streamTrim()

### DIFF
--- a/src/t_stream.c
+++ b/src/t_stream.c
@@ -747,7 +747,7 @@ int64_t streamTrim(stream *s, streamAddTrimArgs *args) {
             streamDecodeID(ri.key, &master_id);
 
             /* Read last ID. */
-            streamID last_id;
+            streamID last_id = {0,0};
             lpGetEdgeStreamID(lp, 0, &master_id, &last_id);
 
             /* We can remove the entire node id its last ID < 'id' */


### PR DESCRIPTION
Reference: https://github.com/redis/redis/actions/runs/3085270862/jobs/4988365752

Confirmation of the fix: https://github.com/filipecosta90/redis/actions/runs/3131273960/jobs/5082442991